### PR TITLE
Lower minimum TTL to 600s

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Because the Hosttech API does not provide a way to manipulate a generic "Type,Na
 Any unsupported record types returns an error.
 
 ### Minimal TTL
-The Time-to-Life has to be at least 600 seconds, anything below that will be rejected by the API
+The Time-to-Life has to be at least 600 seconds. If you try to set a lower value, the client will
+automatically set it to 600 seconds. Smaller values would be rejected by the Hosttech API.
 
 ## Further documentation
 Any further documentation that could be helpful:

--- a/models.go
+++ b/models.go
@@ -232,9 +232,9 @@ func (t TLSARecord) fromLibdnsRecord(record libdns.Record) HosttechRecord {
 
 func durationToIntSeconds(duration time.Duration) int {
 	durationInSeconds := duration.Seconds()
-	//The minimum amount is 10800 seconds
-	if durationInSeconds < 10800 {
-		return 10800
+	// The minimum amount is 600 seconds
+	if durationInSeconds < 600 {
+		return 600
 	}
 	return int(durationInSeconds)
 }


### PR DESCRIPTION
This fixes that records can't be set with a TTL of 3600 to 10800.

Practice has shown that the Hosttech API does in fact support a TTL of 3600 which is why this client library should support that.