### PR TITLE
Update Provider.SetRecords documentation to clearly state it is for updates only

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -83,7 +83,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	return successfullyAppendedRecords, nil
 }
 
-// SetRecords sets the records in the zone, either by updating existing records or creating new ones.
+// SetRecords updates the records in the zone. This requires record IDs to be set.
 // It returns the updated records.
 func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
 	successfullyUpdatedRecords := []libdns.Record{}


### PR DESCRIPTION
This PR aims to clarify that the SetRecords function is only
usable for updating existing records.

As the current API documentation states:
> Modifies a record of a zone and returns the updated record

See: https://api.ns1.hosttech.eu/api/documentation/#/Records/put_api_user_v1_zones__zoneId__records__recordId_

Closes #11